### PR TITLE
Use protocol relative URIs

### DIFF
--- a/views/discover.haml
+++ b/views/discover.haml
@@ -17,8 +17,8 @@
 			%footer
 				%div=haml :footer
 
-%script{ :type => "text/javascript", :src =>"https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"}
-%script{ :type => "text/javascript", :src => "http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/js/bootstrap.min.js" }
+%script{ :type => "text/javascript", :src =>"//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"}
+%script{ :type => "text/javascript", :src => "//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/js/bootstrap.min.js" }
 :javascript
 	var match = function() {
 		var input = $('#input').val();

--- a/views/index.haml
+++ b/views/index.haml
@@ -25,9 +25,9 @@
 			%footer
 				%div=haml :footer
 
-%script{ :type => "text/javascript", :src =>"https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"}
-%script{ :type => "text/javascript", :src => "http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/js/bootstrap.min.js" }
-%script{ :type => "text/javascript", :src => "https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" }
+%script{ :type => "text/javascript", :src =>"//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"}
+%script{ :type => "text/javascript", :src => "//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/js/bootstrap.min.js" }
+%script{ :type => "text/javascript", :src => "//ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" }
 :javascript
 	var match = function() {
 		var input = $('#input').val();

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -8,12 +8,12 @@
 		:plain
 			<!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
 			<!--[if lt IE 9]>
-				<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+				<script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
 			<![endif]-->
 
 		/ Le styles
-		%link{ :href => "http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap.min.css", :rel => "stylesheet" }
-		%link{ :href => "http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.0/themes/ui-lightness/jquery-ui.css", :rel => "stylesheet" }
+		%link{ :href => "//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap.min.css", :rel => "stylesheet" }
+		%link{ :href => "//ajax.googleapis.com/ajax/libs/jqueryui/1.9.0/themes/ui-lightness/jquery-ui.css", :rel => "stylesheet" }
 		%link{ :href => "sticky.css", :rel => "stylesheet"}
 		/ Le fav and touch icons 
 		%link{ rel: "apple-touch-icon", href: "/bootstrap/images/apple-touch-icon.png"}

--- a/views/patterns.haml
+++ b/views/patterns.haml
@@ -18,7 +18,7 @@
 		.footer-wrapper
 			%footer
 				%div=haml :footer
-%script{ :type => "text/javascript", :src =>"https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"}
+%script{ :type => "text/javascript", :src =>"//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"}
 :javascript
 	$("a").click(function () {
 		$.get('patterns/' + $(this).attr("class"), function(data){


### PR DESCRIPTION
This way we don't get a "insecure contents" warning when users are using
https to navigate to grokdebug and we don't "waste" resources using
https resources when people are navigating to grokdebug using http.

I'm all for only using SSL though, it's up to you.
