### PR TITLE
New feature: Custom patterns in the debugger

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -62,7 +62,7 @@ class Application < Sinatra::Base
     end 
     
     begin
-      grok.compile(params[:pattern])          
+      grok.compile(params[:pattern])
     rescue 
       return "Compile ERROR"
     end
@@ -121,20 +121,13 @@ class Application < Sinatra::Base
   end
 
   post '/discover' do
-    custom_patterns = params[:custom_patterns]    
-    if !custom_patterns.empty?
-      add_custom_patterns_from_string(custom_patterns)
-    end 
-    
-    discovered = grok.discover(params[:input])
-    print "#{discovered}"
-    discovered
+    grok.discover(params[:input])
   end
   
   get '/' do
     @tags = []
     grok.patterns.each do |x,y|
-        @tags << "%{#{x}"        
+        @tags << "%{#{x}"
     end
     haml :'index'
   end

--- a/app.rb
+++ b/app.rb
@@ -34,17 +34,35 @@ class Application < Sinatra::Base
     end
   end
 
+  def add_custom_patterns_from_string(text)
+    text.each_line do |line|
+      # Skip comments
+      next if line =~ /^\s*#/ 
+      # File format is: NAME ' '+ PATTERN '\n'
+      name, pattern = line.gsub(/^\s*/, "").split(/\s+/, 2)
+      #p name => pattern
+      # If the line is malformed, skip it.
+      next if pattern.nil?
+      # Trim newline and add the pattern.
+      grok.add_pattern(name, pattern.chomp)
+      end
+  end
+
   set :public_folder, File.dirname(__FILE__) + '/public'
   post '/grok' do
-
+    custom_patterns = params[:custom_patterns]    
     input = params[:input]
     pattern = params[:pattern]
     named_captures_only = (params[:named_captures_only] == "true")
     singles = (params[:singles] == "true")
     keep_empty_captures = (params[:keep_empty_captures] == "true")
-
+    
+    if !custom_patterns.empty?
+      add_custom_patterns_from_string(custom_patterns)
+    end 
+    
     begin
-      grok.compile(params[:pattern])
+      grok.compile(params[:pattern])          
     rescue 
       return "Compile ERROR"
     end
@@ -103,13 +121,20 @@ class Application < Sinatra::Base
   end
 
   post '/discover' do
-    grok.discover(params[:input])
+    custom_patterns = params[:custom_patterns]    
+    if !custom_patterns.empty?
+      add_custom_patterns_from_string(custom_patterns)
+    end 
+    
+    discovered = grok.discover(params[:input])
+    print "#{discovered}"
+    discovered
   end
   
   get '/' do
     @tags = []
     grok.patterns.each do |x,y|
-        @tags << "%{#{x}"
+        @tags << "%{#{x}"        
     end
     haml :'index'
   end

--- a/views/index.haml
+++ b/views/index.haml
@@ -2,10 +2,13 @@
 	.content
 		.wrapper
 			.proper-content				
-				%form{ :action => "#", :id => "grok-form" }
+				%form{ :action => "#", :id => "grok-form" }						
 					%input{ :type => "text", :class => "span12", :placeholder => "Input", :id => "input" }
 					.ui-widget
 						%input{ :type => "text", :class => "span12", :placeholder => "Pattern", :id => "tags" }
+					%lable{ :class => "checkbox inline",}
+						%input{ :id => "add_custom_patterns", :type => "checkbox", :value= => "" }
+							Add custom patterns
 					%lable{ :class => "checkbox inline",}
 						%input{ :id => "keep_empty_captures", :type => "checkbox", :value= => "" }
 							Keep Empty Captures
@@ -18,6 +21,10 @@
 					%label{ :class => "checkbox inline pull-right" }
 						%input{ :id => "autocomplete", :type => "checkbox", :value => "" }
 							Autocomplete
+				%div{:id => "custom_patterns_container", :style=>"display:none;"}
+					%p
+						One per line, the syntax for a grok pattern is <code>%{SYNTAX:SEMANTIC}</code>
+					%textarea{ :class => "span12", :placeholder => "Custom patterns", :id => "custom_patterns", }									
 				%div{ :class => "well" }
 					%pre{ :id => "grok" }
 			.push
@@ -30,6 +37,7 @@
 %script{ :type => "text/javascript", :src => "//ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" }
 :javascript
 	var match = function() {
+		var custom_patterns = $('#custom_patterns').val();		
 		var input = $('#input').val();
 		var pattern = $('#tags').val();
 		var named_captures_only = $('#named_captures_only').is(':checked');
@@ -38,6 +46,7 @@
 		
 		$.post('/grok',
 			{
+			    "custom_patterns":custom_patterns,
 				"input":input,
 				"pattern":pattern,
 				"named_captures_only":named_captures_only,
@@ -60,6 +69,11 @@
 			match();
 		}
 	}, 1000);
+	$("#add_custom_patterns").click(function(){
+		$( "#custom_patterns_container" ).toggle(function() {
+			$( "#custom_patterns" ).val("")
+		})
+	})
 	$("#named_captures_only").click(function(){
 		 match();
 	})
@@ -75,7 +89,7 @@
 	});
 	$("#grok-form").submit(match);
 
-	var availableTags = #{@tags};
+	var availableTags = #{@tags};	
 
 	function split( val ) {
 	    return val.split( /}\s*/ );
@@ -96,6 +110,14 @@
 	        minLength: 3,
 	        disabled: true,
 	        source: function( request, response ) {
+	        	$.each($( "#custom_patterns" ).val().split('\n'), function(){
+					var line_splitted = this.replace(/^\s*/, "").split(/\s+/)
+					var name = line_splitted[0]
+					if ( $.inArray(name, availableTags) == -1 ) {
+						availableTags.push("%{" + name)
+					}
+				});
+
 	            // delegate back to autocomplete, but extract the last term
 	            response( $.ui.autocomplete.filter(
 	                availableTags, extractLast( request.term ) ) );

--- a/views/index.haml
+++ b/views/index.haml
@@ -2,7 +2,7 @@
 	.content
 		.wrapper
 			.proper-content				
-				%form{ :action => "#", :id => "grok-form" }						
+				%form{ :action => "#", :id => "grok-form" }
 					%input{ :type => "text", :class => "span12", :placeholder => "Input", :id => "input" }
 					.ui-widget
 						%input{ :type => "text", :class => "span12", :placeholder => "Pattern", :id => "tags" }
@@ -89,7 +89,7 @@
 	});
 	$("#grok-form").submit(match);
 
-	var availableTags = #{@tags};	
+	var availableTags = #{@tags};
 
 	function split( val ) {
 	    return val.split( /}\s*/ );


### PR DESCRIPTION
**Specs**
As a user, when I debug an input, I should be able to use my own patterns
As a user, when I use the autocompletion, the debugger should propose
me my own patterns.

**Demo**
http://grokdebug-danielpetisme.herokuapp.com/

Check the "Add custom patterns" checkbox to toggle the textarea. The edition format is classic, one pattern per line.
Then you will be able to use the custom pattern in the pattern field. If you trigger the autocompletion, the suggestions will include the custom patterns.

**Code**
The custom patterns are transmitted to the backend. The backend do basic validations (empty). Then, it will parse and extract the the custom patterns before adding them to the grok instance patterns. 

Regarding the autocompletion, when it's trying to load the "available tags" (ie. the defaults ones), the JS will read the custom patterns textarea, parse them and add them in the "availableTags" collection. A verification is made to only have unique values in the final list.
