### PR TITLE
Fix the case where the matched strings contain HTML chars that need escaping

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@ require 'sinatra'
 require 'grok-pure'
 require 'json'
 require 'find'
+require 'cgi'
 
 class Application < Sinatra::Base
   
@@ -95,8 +96,21 @@ class Application < Sinatra::Base
     end
 
     if fields
+      #Keep escaped strings before generating json in escaped_fields dict
+      escaped_fields = {}
+      fields.each do |key, value|
+        if singles
+          value.map! { |x| CGI.escapeHTML(x) if x != nil }
+        else
+          value.each_index do |i|
+            value[i].map! { |x| CGI.escapeHTML(x) if x != nil}
+          end
+        end
+        escaped_fields[CGI.escapeHTML(key)] = value
+      end
+
     #pp match.captures
-      return JSON.pretty_generate(fields)
+      return JSON.pretty_generate(escaped_fields)
     end
 
     return "No Matches"


### PR DESCRIPTION
For the idea of what the issue is, 

Not working:
![2013-11-26-153319_965x309_scrot](https://f.cloud.github.com/assets/631797/1621020/a6209ba6-5684-11e3-95db-ef63552a3e79.png)

After the patch:
![2013-11-26-153435_969x353_scrot](https://f.cloud.github.com/assets/631797/1621024/b0692600-5684-11e3-98e1-0c3f9ca1bfa5.png)

Basically, I've used `CGI.escapeHTML` to escape the strings while sending back json data to browser.
